### PR TITLE
Polygon Colliders, proper offsets

### DIFF
--- a/Custom 2D Colliders/Scripts/ArcCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/ArcCollider2D.cs
@@ -35,9 +35,9 @@ using System.Collections.Generic;
 [RequireComponent(typeof(PolygonCollider2D))]
 public class ArcCollider2D : MonoBehaviour {
 
-    [Range(1, 25)]
+    [Range(1, 25), HideInInspector]
     public float radius = 3;
-    [Range(1, 25)]
+    [Range(1, 25), HideInInspector]
     public float Thickness = 0.4f;
     [Range(10,90)]
     public int smoothness = 24;
@@ -50,6 +50,9 @@ public class ArcCollider2D : MonoBehaviour {
 
     [Header("Let there be Pizza")]
     public bool pizzaSlice;
+
+    [HideInInspector]
+    public bool advanced = false;
     
     Vector2 origin, center;
     
@@ -80,11 +83,11 @@ public class ArcCollider2D : MonoBehaviour {
         {
             for (int i = 0; i <= smoothness; i++)
             {
+                ang -= (float)totalAngle / smoothness;
                 float x = (radius - Thickness) * Mathf.Cos(ang * Mathf.Deg2Rad);
                 float y = (radius - Thickness) * Mathf.Sin(ang * Mathf.Deg2Rad);
 
                 points.Add(new Vector2(x, y));
-                ang -= (float)totalAngle/smoothness;
             }
         }
 

--- a/Custom 2D Colliders/Scripts/ArcCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/ArcCollider2D.cs
@@ -32,11 +32,13 @@ using System.Collections.Generic;
 
 [AddComponentMenu("Physics 2D/Arc Collider 2D")]
 
-[RequireComponent(typeof(EdgeCollider2D))]
+[RequireComponent(typeof(PolygonCollider2D))]
 public class ArcCollider2D : MonoBehaviour {
 
     [Range(1, 25)]
     public float radius = 3;
+    [Range(1, 25)]
+    public float Thickness = 0.4f;
     [Range(10,90)]
     public int smoothness = 24;
 
@@ -60,15 +62,30 @@ public class ArcCollider2D : MonoBehaviour {
         
         float ang = offsetRotation;
 
-        if (pizzaSlice && totalAngle % 360 != 0) points.Add(center);
+        if (pizzaSlice && totalAngle % 360 != 0)
+        {
+            points.Add(center);
+        }
 
         for (int i = 0; i <= smoothness; i++)
         {
-            float x = center.x + radius * Mathf.Cos(ang * Mathf.Deg2Rad);
-            float y = center.y + radius * Mathf.Sin(ang * Mathf.Deg2Rad);
+            float x = radius * Mathf.Cos(ang * Mathf.Deg2Rad);
+            float y = radius * Mathf.Sin(ang * Mathf.Deg2Rad);
 
             points.Add(new Vector2(x, y));
             ang += (float)totalAngle/smoothness;
+        }
+
+        if (!pizzaSlice)
+        {
+            for (int i = 0; i <= smoothness; i++)
+            {
+                float x = (radius - Thickness) * Mathf.Cos(ang * Mathf.Deg2Rad);
+                float y = (radius - Thickness) * Mathf.Sin(ang * Mathf.Deg2Rad);
+
+                points.Add(new Vector2(x, y));
+                ang -= (float)totalAngle/smoothness;
+            }
         }
 
         if (pizzaSlice && totalAngle % 360 != 0) points.Add(center);

--- a/Custom 2D Colliders/Scripts/CapsuleCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/CapsuleCollider2D.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 The MIT License (MIT)
 
 Copyright (c) 2016 GuyQuad
@@ -32,7 +32,7 @@ using System.Collections.Generic;
 
 [AddComponentMenu("Physics 2D/Capsule Collider 2D")]
 
-[RequireComponent(typeof(EdgeCollider2D))]
+[RequireComponent(typeof(PolygonCollider2D))]
 public class CapsuleCollider2D : MonoBehaviour {
 
     [HideInInspector]
@@ -55,27 +55,26 @@ public class CapsuleCollider2D : MonoBehaviour {
     List<Vector2> points;
     float ang = 0;
 
-    public Vector2[] getPoints(Vector2 off)
+    public Vector2[] getPoints()
     {
         points = new List<Vector2>();
 
         origin = transform.localPosition;
-        center = origin + off;
 
         float r = (height / 2f) - (radius);
 
         if (bullet && flip) r += radius;
         
-        center1.x = center.x + r * Mathf.Sin(rotation * Mathf.Deg2Rad);
-        center1.y = center.y + r * Mathf.Cos(rotation * Mathf.Deg2Rad);
+        center1.x = r * Mathf.Sin(rotation * Mathf.Deg2Rad);
+        center1.y = r * Mathf.Cos(rotation * Mathf.Deg2Rad);
 
         if (bullet) {
             if (!flip) r += radius;
             else r -= radius;
         }
 
-        center2.x = center.x + r * Mathf.Sin((rotation + 180f) * Mathf.Deg2Rad);
-        center2.y = center.y + r * Mathf.Cos((rotation + 180f) * Mathf.Deg2Rad);
+        center2.x = r * Mathf.Sin((rotation + 180f) * Mathf.Deg2Rad);
+        center2.y = r * Mathf.Cos((rotation + 180f) * Mathf.Deg2Rad);
 
 
 
@@ -120,7 +119,6 @@ public class CapsuleCollider2D : MonoBehaviour {
             }
         }
 
-        points.Add(points[0]);
         return points.ToArray();
     }
 

--- a/Custom 2D Colliders/Scripts/Editor/ArcCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/ArcCollider2D_Editor.cs
@@ -33,19 +33,19 @@ using System.Collections;
 public class ArcCollider_Editor : Editor {
     
     ArcCollider2D ac;
-    EdgeCollider2D edgeCollider;
+    PolygonCollider2D polyCollider;
     Vector2 off;
 
     void OnEnable()
     {
         ac = (ArcCollider2D)target;
 
-        edgeCollider = ac.GetComponent<EdgeCollider2D>();
-        if (edgeCollider == null) {
-            ac.gameObject.AddComponent<EdgeCollider2D>();
-            edgeCollider = ac.GetComponent<EdgeCollider2D>();
+        polyCollider = ac.GetComponent<PolygonCollider2D>();
+        if (polyCollider == null) {
+            ac.gameObject.AddComponent<PolygonCollider2D>();
+            polyCollider = ac.GetComponent<PolygonCollider2D>();
         }
-        edgeCollider.points = ac.getPoints(edgeCollider.offset);
+        polyCollider.points = ac.getPoints(polyCollider.offset);
     }
 
     public override void OnInspectorGUI()
@@ -53,11 +53,11 @@ public class ArcCollider_Editor : Editor {
         GUI.changed = false;
         DrawDefaultInspector();
 
-        if (GUI.changed || !off.Equals(edgeCollider.offset))
+        if (GUI.changed || !off.Equals(polyCollider.offset))
         {
-            edgeCollider.points = ac.getPoints(edgeCollider.offset);
+            polyCollider.points = ac.getPoints(polyCollider.offset);
         }
-        off = edgeCollider.offset;
+        off = polyCollider.offset;
     }
     
 }

--- a/Custom 2D Colliders/Scripts/Editor/ArcCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/ArcCollider2D_Editor.cs
@@ -53,6 +53,27 @@ public class ArcCollider_Editor : Editor {
         GUI.changed = false;
         DrawDefaultInspector();
 
+        ac.advanced = EditorGUILayout.Toggle("Advanced", ac.advanced);
+        if (ac.advanced)
+        {
+            ac.radius = EditorGUILayout.FloatField("Radius", ac.radius);
+        }
+        else
+        {
+            ac.radius = EditorGUILayout.Slider("Radius", ac.radius, 1, 25);
+        }
+        if (!ac.pizzaSlice)
+        {
+            if (ac.advanced)
+            {
+                ac.Thickness = EditorGUILayout.FloatField("Thickness", ac.Thickness);
+            }
+            else
+            {
+                ac.Thickness = EditorGUILayout.Slider("Thickness", ac.Thickness, 1, 25);
+            }
+        }
+
         if (GUI.changed || !off.Equals(polyCollider.offset))
         {
             polyCollider.points = ac.getPoints(polyCollider.offset);

--- a/Custom 2D Colliders/Scripts/Editor/CapsuleCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/CapsuleCollider2D_Editor.cs
@@ -33,7 +33,7 @@ using System.Collections;
 public class CapsuleCollider_Editor : Editor {
 
     CapsuleCollider2D capCol;
-    EdgeCollider2D edgeCollider;
+    PolygonCollider2D polyCollider;
     Vector2 off;
     bool advanced;
 
@@ -41,13 +41,12 @@ public class CapsuleCollider_Editor : Editor {
     {
         capCol = (CapsuleCollider2D)target;
 
-        edgeCollider = capCol.GetComponent<EdgeCollider2D>();
-        if (edgeCollider == null) {
-            capCol.gameObject.AddComponent<EdgeCollider2D>();
-            edgeCollider = capCol.GetComponent<EdgeCollider2D>();
+        polyCollider = capCol.GetComponent<PolygonCollider2D>();
+        if (polyCollider == null) {
+            polyCollider = capCol.gameObject.AddComponent<PolygonCollider2D>();
         }
 
-        edgeCollider.points = capCol.getPoints(edgeCollider.offset);
+        polyCollider.points = capCol.getPoints();
     }
 
     public override void OnInspectorGUI()
@@ -63,12 +62,12 @@ public class CapsuleCollider_Editor : Editor {
         if(capCol.bullet) capCol.flip = EditorGUILayout.Toggle("Flip", capCol.flip);
 
 
-        if (GUI.changed || !off.Equals(edgeCollider.offset))
+        if (GUI.changed || !off.Equals(polyCollider.offset))
         {
-            edgeCollider.points = capCol.getPoints(edgeCollider.offset);
+            polyCollider.points = capCol.getPoints();
         }
 
-        off = edgeCollider.offset;
+        off = polyCollider.offset;
     }
     
 }

--- a/Custom 2D Colliders/Scripts/Editor/EllipseCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/EllipseCollider2D_Editor.cs
@@ -33,19 +33,18 @@ using System.Collections;
 public class EllipseCollider_Editor : Editor {
 
     EllipseCollider2D ec;
-    EdgeCollider2D edgeCollider;
+    PolygonCollider2D polyCollider;
     Vector2 off;
 
     void OnEnable()
     {
         ec = (EllipseCollider2D)target;
 
-        edgeCollider = ec.GetComponent<EdgeCollider2D>();
-        if (edgeCollider == null) {
-            ec.gameObject.AddComponent<EdgeCollider2D>();
-            edgeCollider = ec.GetComponent<EdgeCollider2D>();
+        polyCollider = ec.GetComponent<PolygonCollider2D>();
+        if (polyCollider == null) {
+            polyCollider = ec.gameObject.AddComponent<PolygonCollider2D>();
         }
-        edgeCollider.points = ec.getPoints(edgeCollider.offset);
+        polyCollider.points = ec.getPoints();
     }
 
     public override void OnInspectorGUI()
@@ -53,12 +52,12 @@ public class EllipseCollider_Editor : Editor {
         GUI.changed = false;
         DrawDefaultInspector();
 
-        if (GUI.changed || !off.Equals(edgeCollider.offset))
+        if (GUI.changed || !off.Equals(polyCollider.offset))
         {
-            edgeCollider.points = ec.getPoints(edgeCollider.offset);
+            polyCollider.points = ec.getPoints();
         }
 
-        off = edgeCollider.offset;
+        off = polyCollider.offset;
     }
     
 }

--- a/Custom 2D Colliders/Scripts/Editor/EllipseCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/EllipseCollider2D_Editor.cs
@@ -52,6 +52,18 @@ public class EllipseCollider_Editor : Editor {
         GUI.changed = false;
         DrawDefaultInspector();
 
+        ec.advanced = EditorGUILayout.Toggle("Advanced", ec.advanced);
+        if (ec.advanced)
+        {
+            ec.radiusX = EditorGUILayout.FloatField("RadiusX", ec.radiusX);
+            ec.radiusY = EditorGUILayout.FloatField("RadiusY", ec.radiusY);
+        }
+        else
+        {
+            ec.radiusX = EditorGUILayout.Slider("RadiusX", ec.radiusX, 1, 25);
+            ec.radiusY = EditorGUILayout.Slider("RadiusY", ec.radiusY, 1, 25);
+        }
+
         if (GUI.changed || !off.Equals(polyCollider.offset))
         {
             polyCollider.points = ec.getPoints();

--- a/Custom 2D Colliders/Scripts/Editor/RoundedBoxCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/RoundedBoxCollider2D_Editor.cs
@@ -33,21 +33,20 @@ using System.Collections;
 public class RoundedBoxCollider_Editor : Editor {
 
     RoundedBoxCollider2D rb;
-    EdgeCollider2D edgeCollider;
+    PolygonCollider2D polyCollider;
     Vector2 off;
 
     void OnEnable()
     {
         rb = (RoundedBoxCollider2D)target;
 
-        edgeCollider = rb.GetComponent<EdgeCollider2D>();
-        if (edgeCollider == null) {
-            rb.gameObject.AddComponent<EdgeCollider2D>();
-            edgeCollider = rb.GetComponent<EdgeCollider2D>();
+        polyCollider = rb.GetComponent<PolygonCollider2D>();
+        if (polyCollider == null) {
+            polyCollider = rb.gameObject.AddComponent<PolygonCollider2D>();
         }
 
-        Vector2[] pts = rb.getPoints(edgeCollider.offset);
-        if (pts != null) edgeCollider.points = pts;
+        Vector2[] pts = rb.getPoints();
+        if (pts != null) polyCollider.points = pts;
     }
 
     public override void OnInspectorGUI()
@@ -70,16 +69,16 @@ public class RoundedBoxCollider_Editor : Editor {
             rb.height = 2;
             rb.trapezoid = 0.5f;
             rb.radius = 0.5f;
-            edgeCollider.offset = Vector2.zero;
+            polyCollider.offset = Vector2.zero;
         }
 
-        if (GUI.changed || !off.Equals(edgeCollider.offset))
+        if (GUI.changed || !off.Equals(polyCollider.offset))
         {
-            Vector2[] pts = rb.getPoints(edgeCollider.offset);
-            if (pts != null) edgeCollider.points = pts;
+            Vector2[] pts = rb.getPoints();
+            if (pts != null) polyCollider.points = pts;
         }
 
-        off = edgeCollider.offset;
+        off = polyCollider.offset;
     }
     
 }

--- a/Custom 2D Colliders/Scripts/Editor/RoundedBoxCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/RoundedBoxCollider2D_Editor.cs
@@ -61,6 +61,18 @@ public class RoundedBoxCollider_Editor : Editor {
         lesser = Mathf.Round(lesser * 100f) / 100f; 
         rb.radius = EditorGUILayout.Slider("Radius",rb.radius, 0f, lesser);
         rb.radius = Mathf.Clamp(rb.radius, 0f, lesser);
+        
+        rb.advanced = EditorGUILayout.Toggle("Advanced", rb.advanced);
+        if (rb.advanced)
+        {
+            rb.height = EditorGUILayout.FloatField("Height", rb.height);
+            rb.width = EditorGUILayout.FloatField("Width", rb.width);
+        }
+        else
+        {
+            rb.height = EditorGUILayout.Slider("Height", rb.height, 1, 25);
+            rb.width = EditorGUILayout.Slider("Width", rb.width, 1, 25);
+        }
 
         if (GUILayout.Button("Reset"))
         {

--- a/Custom 2D Colliders/Scripts/Editor/StarCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/StarCollider2D_Editor.cs
@@ -55,6 +55,18 @@ public class StarCollider_Editor : Editor {
 
         sc.rotation = EditorGUILayout.IntSlider("Rotation", sc.rotation, 0, 360 / sc.points);
 
+        sc.advanced = EditorGUILayout.Toggle("Advanced", sc.advanced);
+        if (sc.advanced)
+        {
+            sc.radiusA = EditorGUILayout.FloatField("RadiusA", sc.radiusA);
+            sc.radiusB = EditorGUILayout.FloatField("RadiusB", sc.radiusB);
+        }
+        else
+        {
+            sc.radiusA = EditorGUILayout.Slider("RadiusA", sc.radiusA, 1, 25);
+            sc.radiusB = EditorGUILayout.Slider("RadiusB", sc.radiusB, 1, 25);
+        }
+
 
         if (GUI.changed || !off.Equals(polyCollider.offset))
         {

--- a/Custom 2D Colliders/Scripts/Editor/StarCollider2D_Editor.cs
+++ b/Custom 2D Colliders/Scripts/Editor/StarCollider2D_Editor.cs
@@ -34,19 +34,18 @@ using System.Collections;
 public class StarCollider_Editor : Editor {
 
     StarCollider2D sc;
-    EdgeCollider2D edgeCollider;
+    PolygonCollider2D polyCollider;
     Vector2 off;
 
     void OnEnable()
     {
         sc = (StarCollider2D)target;
 
-        edgeCollider = sc.GetComponent<EdgeCollider2D>();
-        if (edgeCollider == null) {
-            sc.gameObject.AddComponent<EdgeCollider2D>();
-            edgeCollider = sc.GetComponent<EdgeCollider2D>();
+        polyCollider = sc.GetComponent<PolygonCollider2D>();
+        if (polyCollider == null) {
+            polyCollider = sc.gameObject.AddComponent<PolygonCollider2D>();
         }
-        edgeCollider.points = sc.getPoints(edgeCollider.offset);
+        polyCollider.points = sc.getPoints();
     }
 
     public override void OnInspectorGUI()
@@ -57,12 +56,12 @@ public class StarCollider_Editor : Editor {
         sc.rotation = EditorGUILayout.IntSlider("Rotation", sc.rotation, 0, 360 / sc.points);
 
 
-        if (GUI.changed || !off.Equals(edgeCollider.offset))
+        if (GUI.changed || !off.Equals(polyCollider.offset))
         {
-            edgeCollider.points = sc.getPoints(edgeCollider.offset);
+            polyCollider.points = sc.getPoints();
         }
 
-        off = edgeCollider.offset;
+        off = polyCollider.offset;
     }
 
 }

--- a/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
@@ -35,7 +35,7 @@ using System.Collections.Generic;
 [RequireComponent(typeof(PolygonCollider2D))]
 public class EllipseCollider2D : MonoBehaviour {
 
-    [Range(1, 25)]
+    [Range(1, 25), HideInInspector]
     public float radiusX = 1, radiusY = 2;
 
     [Range(10,90)]
@@ -43,7 +43,10 @@ public class EllipseCollider2D : MonoBehaviour {
 
     [Range(0, 180)]
     public int rotation = 0;
-    
+
+    [HideInInspector]
+    public bool advanced = false;
+
     Vector2 origin, center;
     
     public Vector2[] getPoints()

--- a/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 The MIT License (MIT)
 
 Copyright (c) 2016 GuyQuad
@@ -46,12 +46,9 @@ public class EllipseCollider2D : MonoBehaviour {
     
     Vector2 origin, center;
     
-    public Vector2[] getPoints(Vector2 off)
+    public Vector2[] getPoints()
     {
         List<Vector2> points = new List<Vector2>();
-
-        origin = transform.localPosition;
-        center = origin + off;
         
         float ang = 0;
         float o = rotation * Mathf.Deg2Rad;
@@ -69,13 +66,14 @@ public class EllipseCollider2D : MonoBehaviour {
             //float y = center.y + radius * Mathf.Sin(a);
 
             // https://www.uwgb.edu/dutchs/Geometry/HTMLCanvas/ObliqueEllipses5a.HTM
-            float x = center.x + radiusX * Mathf.Cos(a) * Mathf.Cos(o) - radiusY * Mathf.Sin(a) * Mathf.Sin(o);
-            float y = center.y - radiusX * Mathf.Cos(a) * Mathf.Sin(o) - radiusY * Mathf.Sin(a) * Mathf.Cos(o);
+            float x = radiusX * Mathf.Cos(a) * Mathf.Cos(o) - radiusY * Mathf.Sin(a) * Mathf.Sin(o);
+            float y = -radiusX * Mathf.Cos(a) * Mathf.Sin(o) - radiusY * Mathf.Sin(a) * Mathf.Cos(o);
 
             points.Add(new Vector2(x, y));
             ang += 360f/smoothness;
         }
 
+        points.RemoveAt(0);
         return points.ToArray();
     }
 }

--- a/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/EllipseCollider2D.cs
@@ -32,7 +32,7 @@ using System.Collections.Generic;
 
 [AddComponentMenu("Physics 2D/Ellipse Collider 2D")]
 
-[RequireComponent(typeof(EdgeCollider2D))]
+[RequireComponent(typeof(PolygonCollider2D))]
 public class EllipseCollider2D : MonoBehaviour {
 
     [Range(1, 25)]

--- a/Custom 2D Colliders/Scripts/RoundedBoxCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/RoundedBoxCollider2D.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 The MIT License (MIT)
 
 Copyright (c) 2016 GuyQuad
@@ -32,7 +32,7 @@ using System.Collections.Generic;
 
 [AddComponentMenu("Physics 2D/Rounded Box Collider 2D")]
 
-[RequireComponent(typeof(EdgeCollider2D))]
+[RequireComponent(typeof(PolygonCollider2D))]
 public class RoundedBoxCollider2D : MonoBehaviour {
     
     [Range(10, 90)]
@@ -51,27 +51,23 @@ public class RoundedBoxCollider2D : MonoBehaviour {
     public float trapezoid = .5f;
 
     [HideInInspector]
-    public Vector2 offset, center, center1, center2, center3, center4;
+    public Vector2 offset, center1, center2, center3, center4;
     float ang = 0;
     List<Vector2> points;
 
-    public Vector2[] getPoints(Vector2 off)
+    public Vector2[] getPoints()
     {
         points = new List<Vector2>();
         points.Clear();
-        
-        offset = off;
-        center = transform.localPosition;
-        center += offset;
 
         wt = (width + width) - ((width + width) * trapezoid);   // width top
         wb = (width + width) * trapezoid;                       // width bottom
         
         // vertices
-        Vector2 vTR = new Vector2(center.x + (wt / 2f), center.y + (height / 2f)); // top right vertex
-        Vector2 vTL = new Vector2(center.x + (wt /-2f), center.y + (height / 2f)); // top left vertex
-        Vector2 vBL = new Vector2(center.x + (wb /-2f), center.y - (height / 2f)); // bottom left vertex
-        Vector2 vBR = new Vector2(center.x + (wb / 2f), center.y - (height / 2f)); // bottom right vertex
+        Vector2 vTR = new Vector2((wt / 2f), +(height / 2f)); // top right vertex
+        Vector2 vTL = new Vector2((wt /-2f), +(height / 2f)); // top left vertex
+        Vector2 vBL = new Vector2((wb /-2f), -(height / 2f)); // bottom left vertex
+        Vector2 vBR = new Vector2((wb / 2f), -(height / 2f)); // bottom right vertex
 
         Vector2 dir = vBL - vTL;
         float hypAngleTL = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg; // hypertenuse angle top left corner
@@ -109,10 +105,10 @@ public class RoundedBoxCollider2D : MonoBehaviour {
 
 
         // prevent overlapping of the corners
-        center1.x = Mathf.Max(center.x, center1.x);
-        center2.x = Mathf.Min(center.x, center2.x);
-        center3.x = Mathf.Min(center.x, center3.x);
-        center4.x = Mathf.Max(center.x, center4.x);
+        center1.x = Mathf.Max(0, center1.x);
+        center2.x = Mathf.Min(0, center2.x);
+        center3.x = Mathf.Min(0, center3.x);
+        center4.x = Mathf.Max(0, center4.x);
 
 
         // curveTOP angles
@@ -159,10 +155,6 @@ public class RoundedBoxCollider2D : MonoBehaviour {
         calcPoints(center3, totalAngle);
         calcPoints(center4, totalAngle);
 
-
-
-
-        points.Add(points[0]);
         return points.ToArray();
     }
 

--- a/Custom 2D Colliders/Scripts/RoundedBoxCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/RoundedBoxCollider2D.cs
@@ -38,10 +38,10 @@ public class RoundedBoxCollider2D : MonoBehaviour {
     [Range(10, 90)]
     public int smoothness = 15;
 
-    [Range(.2f, 25)]
+    [Range(.2f, 25), HideInInspector]
     public float height = 2;
 
-    [Range(.2f, 25)]
+    [Range(.2f, 25), HideInInspector]
     public float width = 2;
 
     [HideInInspector]
@@ -52,6 +52,10 @@ public class RoundedBoxCollider2D : MonoBehaviour {
 
     [HideInInspector]
     public Vector2 offset, center1, center2, center3, center4;
+
+    [HideInInspector]
+    public bool advanced = false;
+
     float ang = 0;
     List<Vector2> points;
 

--- a/Custom 2D Colliders/Scripts/StarCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/StarCollider2D.cs
@@ -67,8 +67,6 @@ public class StarCollider2D : MonoBehaviour {
             ang += 360f/(points*2f);
         }
 
-        pts.Add(pts[0]);
-
         return pts.ToArray();
     }
 }

--- a/Custom 2D Colliders/Scripts/StarCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/StarCollider2D.cs
@@ -35,10 +35,10 @@ using System.Collections.Generic;
 [RequireComponent(typeof(PolygonCollider2D))]
 public class StarCollider2D : MonoBehaviour {
 
-    [Range(1, 25)]
+    [Range(1, 25), HideInInspector]
     public float radiusA = 1;
 
-    [Range(1, 25)]
+    [Range(1, 25), HideInInspector]
     public float radiusB = 2;
 
     [Range(3,36)]
@@ -46,7 +46,10 @@ public class StarCollider2D : MonoBehaviour {
     
     [HideInInspector]
     public int rotation = 0;
-    
+
+    [HideInInspector]
+    public bool advanced = false;
+
     Vector2 origin, center;
     
     public Vector2[] getPoints()

--- a/Custom 2D Colliders/Scripts/StarCollider2D.cs
+++ b/Custom 2D Colliders/Scripts/StarCollider2D.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 The MIT License (MIT)
 
 Copyright (c) 2016 GuyQuad
@@ -32,7 +32,7 @@ using System.Collections.Generic;
 
 [AddComponentMenu("Physics 2D/Star Collider 2D")]
 
-[RequireComponent(typeof(EdgeCollider2D))]
+[RequireComponent(typeof(PolygonCollider2D))]
 public class StarCollider2D : MonoBehaviour {
 
     [Range(1, 25)]
@@ -49,20 +49,19 @@ public class StarCollider2D : MonoBehaviour {
     
     Vector2 origin, center;
     
-    public Vector2[] getPoints(Vector2 off)
+    public Vector2[] getPoints()
     {
         List<Vector2> pts = new List<Vector2>();
 
         origin = transform.localPosition;
-        center = origin + off;
 
         float ang = rotation;
 
         for (int i = 0; i <= points * 2; i++)
         {
             float radius = (i % 2 == 0) ? radiusA : radiusB;
-            float x = center.x + radius * Mathf.Cos(ang * Mathf.Deg2Rad);
-            float y = center.y + radius * Mathf.Sin(ang * Mathf.Deg2Rad);
+            float x = radius * Mathf.Cos(ang * Mathf.Deg2Rad);
+            float y = radius * Mathf.Sin(ang * Mathf.Deg2Rad);
 
             pts.Add(new Vector2(x, y));
             ang += 360f/(points*2f);


### PR DESCRIPTION
I made some modifications to make the closed shape colliders (capsule, ellipse, rounded box, star) use the polygon collider rather than the edge collider. This makes them solid like the primitive colliders rather than hollow.

The offsets very for the ones I changed were over correcting. The collider points were offset by the object's position. This is an over correction so I removed that part.
